### PR TITLE
adding r-stringi to conda environment

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -16,6 +16,7 @@ dependencies:
   - r-ggplot2
   - r-rcolorbrewer
   - r-cairo
+  - r-stringi
 # custom recipes from CGR's conda channel
   - annotate_frequency
   - annotate_rsids_from_linker


### PR DESCRIPTION
stringi seems to be required by construct.model.matrix